### PR TITLE
ensure to match Path.basename with string

### DIFF
--- a/test/exactor_test.exs
+++ b/test/exactor_test.exs
@@ -75,7 +75,7 @@ defmodule ExActorTest do
     assert TestActor.get(actor) == 6
 
     {line, exception} = TestActor.test_exc(actor)
-    assert (exception[:file] |> Path.basename) == 'exactor_test.exs'
+    assert (exception[:file] |> Path.basename |> to_string) == "exactor_test.exs"
     assert exception[:line] == line
 
     assert TestActor.test_from(actor) == :ok


### PR DESCRIPTION
It's intended to catch up with the following change.

https://github.com/elixir-lang/elixir/releases/tag/v0.13.1
  [Path] The functions in Path now only emit strings as result, regardless if the input was a char list or a string
