### PR TITLE
Relaxed overly-strict dependency on Elixir ~>1.0.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ExActor.Mixfile do
     [
       project: "ExActor",
       version: @version,
-      elixir: "~> 1.0.0",
+      elixir: "~> 1.0",
       app: :exactor,
       deps: deps,
       package: [


### PR DESCRIPTION
The following error occurs when trying to compile my project that depends on ExActor on Elixir v1.1.0-dev:
```text
warning: the dependency exactor requires Elixir "~> 1.0.0" but you are running on v1.1.0-dev
```

ExActor's tests pass on Elixir v1.1.0-dev when changing the Elixir dependency to ~>1.0, so I don't see a reason to prevent ExActor from running on that version.