### PR TITLE
Add warn_missing: false to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The stable package is available on [hex](https://hex.pm/packages/exactor).
 Be sure to include a dependency in your `mix.exs`:
 
 ```elixir
-deps: [{:exactor, "~> 2.2.0"}, ...]
+deps: [{:exactor, "~> 2.2.0", warn_missing: false}, ...]
 ```
 
 `ExActor` is a compile-time dependency only. No need to add it into the list of dependent applications. All code transformations are performed at compile time.


### PR DESCRIPTION
If people are using exrm, this is necessary to avoid warnings if you do not want to add it to your :applications